### PR TITLE
Fix grunt-contrib-imagemin errors (at npm i).

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-contrib-imagemin": "~0.3.0",
+    "grunt-contrib-imagemin": "0.x",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",


### PR DESCRIPTION
Hi @JulienYo, I encountered many `ENOENT` errors with `grunt-contrib-imagemin` when trying to `npm i`. 
This PR just updates the package version.
